### PR TITLE
[Ansible] site.ymlで対象ホスト別に処理の振り分けをするように修正

### DIFF
--- a/ansible/site/site_web_db.yml
+++ b/ansible/site/site_web_db.yml
@@ -6,7 +6,7 @@
     #- common
     #- sshd
 
-- name: setting m/w
+- name: setting for web
   hosts: vagrant_web
   become: true
 
@@ -15,4 +15,11 @@
     - git
     - rbenv
     - python
+
+- name: setting for db
+  hosts: vagrant_db
+  become: true
+
+  roles:
+    - git
     - mongodb


### PR DESCRIPTION
[Ansible] site.ymlで対象ホスト別に処理の振り分けをするように修正

対象ホストに以下の2つを想定して、実行するタスクを振り分けた
 - web
 - db